### PR TITLE
fix: fix invalid calculation in shopping list

### DIFF
--- a/src/meal_plan/shopping_list.ts
+++ b/src/meal_plan/shopping_list.ts
@@ -142,7 +142,7 @@ function mergeIngredientLists(left: Ingredient[], right: Ingredient[]) {
             return existing.description === i.description && i.unitOfMeasure === existing.unitOfMeasure;
         });
         if (existing === -1) {
-            left.push(i);
+            left.push(structuredClone(i));
         } else {
             let raw = left[existing].quantity ?? 0;
             raw += i.quantity ?? 0;


### PR DESCRIPTION
This was happening because the ingredient reference that we mutated and incremented the quantity on is the same reference in the ingredient instance. This resulted in exponential increase in ingredient amount.